### PR TITLE
Added bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
         "Silvestre Herrera"
     ],
     "dependencies": {
-        "jquery": "*",
+        "jquery": "*"
     },
     "license": "MIT",
     "homepage": "https://github.com/silvestreh/onScreen",


### PR DESCRIPTION
Saw the repo wasn't on bower so added the json file needed so you can get this registered. 

Believe you will just need to run `bower register onScreen https://github.com/silvestreh/onScreen.git` to get it registered.
