### PR TITLE
Have DOM elements registered with onScreen emit `onScreen.in` and `onScreen.out` events

### DIFF
--- a/jquery.onscreen.js
+++ b/jquery.onscreen.js
@@ -194,6 +194,7 @@
                         $el.addClass(params.toggleClass);
                     }
                     if ($.isFunction(params.doIn)) {
+                        $el.trigger('onScreen.in')
                         params.doIn.call($el[0]);
                     }
                     if (params.lazyAttr && $el.prop('tagName') === 'IMG') {
@@ -218,6 +219,7 @@
                         $el.removeClass(params.toggleClass);
                     }
                     if ($.isFunction(params.doOut)) {
+                        $el.trigger('onScreen.out')
                         params.doOut.call($el[0]);
                     }
                     isOnScreen = false;


### PR DESCRIPTION
This concept allows us to listen for an element going in and out of the screen using traditional methods. In particular, we needed to be able to `$el.one(function() { ... })`.

This is what we would like to do...
```
$el.onScreen()
$el.on('onScreen.in', function () { ... })
```

This pull request might need work because we still need to have the `doIn` and `doOut` callbacks defined in the options object for onScreen in order for the event triggers to get fired.