### PR TITLE
Add default parameters to Object.keys() calls in off() method; Fixes #53

### DIFF
--- a/lib/methods/off.js
+++ b/lib/methods/off.js
@@ -7,8 +7,8 @@
  * @return {void}
  */
 function off(event, selector, handler) {
-    const enterCallbacks = Object.keys(this.trackedElements[selector].enter);
-    const leaveCallbacks = Object.keys(this.trackedElements[selector].leave);
+    const enterCallbacks = Object.keys(this.trackedElements[selector].enter || {});
+    const leaveCallbacks = Object.keys(this.trackedElements[selector].leave || {});
 
     if ({}.hasOwnProperty.call(this.trackedElements, selector)) {
         if (handler) {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -79,7 +79,7 @@ describe('Tracking', () => {
 
         instance.off('leave', target, 'anonymous');
         expect(typeof instance.trackedElements[target].leave.anonymous).to.equal('undefined');
-    })
+    });
 
     it('should remove both enter and leave callbacks (named and anonymous)', () => {
         function enterCB() {}

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -51,7 +51,37 @@ describe('Tracking', () => {
             .to.throw('hello event is not supported');
     });
 
-    it('should remove a callback', () => {
+    it('should remove an enter callback (named and anonymous)', () => {
+        const target = '.target'
+
+        function enterCB() {}
+
+        instance.on('enter', target, enterCB);
+        instance.on('enter', target, () => {});
+
+        instance.off('enter', target, enterCB);
+        expect(typeof instance.trackedElements[target].enter.enterCB).to.equal('undefined');
+
+        instance.off('enter', target, 'anonymous')
+        expect(typeof instance.trackedElements[target].enter.anonymous).to.equal('undefined');
+    });
+
+    it('should remove a leave callback (named and anonymous)', () => {
+        const target = '.target'
+
+        function leaveCB() {}
+
+        instance.on('leave', target, leaveCB);
+        instance.on('leave', target, () => {});
+
+        instance.off('leave', target, leaveCB);
+        expect(typeof instance.trackedElements[target].leave.leaveCB).to.equal('undefined');
+
+        instance.off('leave', target, 'anonymous')
+        expect(typeof instance.trackedElements[target].leave.anonymous).to.equal('undefined');
+    })
+
+    it('should remove both enter and leave callbacks (named and anonymous)', () => {
         function enterCB() {}
         instance.on('enter', '.target', enterCB);
         instance.on('leave', '.target', () => {});

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -52,7 +52,7 @@ describe('Tracking', () => {
     });
 
     it('should remove an enter callback (named and anonymous)', () => {
-        const target = '.target'
+        const target = '.target';
 
         function enterCB() {}
 
@@ -62,12 +62,12 @@ describe('Tracking', () => {
         instance.off('enter', target, enterCB);
         expect(typeof instance.trackedElements[target].enter.enterCB).to.equal('undefined');
 
-        instance.off('enter', target, 'anonymous')
+        instance.off('enter', target, 'anonymous');
         expect(typeof instance.trackedElements[target].enter.anonymous).to.equal('undefined');
     });
 
     it('should remove a leave callback (named and anonymous)', () => {
-        const target = '.target'
+        const target = '.target';
 
         function leaveCB() {}
 
@@ -77,7 +77,7 @@ describe('Tracking', () => {
         instance.off('leave', target, leaveCB);
         expect(typeof instance.trackedElements[target].leave.leaveCB).to.equal('undefined');
 
-        instance.off('leave', target, 'anonymous')
+        instance.off('leave', target, 'anonymous');
         expect(typeof instance.trackedElements[target].leave.anonymous).to.equal('undefined');
     })
 


### PR DESCRIPTION
I have added a default empty object as a parameter to the `Object.keys()` methods used in the `off()` function. This prevents an error that occurs when callbacks are supplied only for `enter` or `leave`.

I also added tests for both enter and leave individually.