### PR TITLE
Uses correct millisecond option for debounce `setTimeout` call

### DIFF
--- a/lib/methods/debounced-scroll.js
+++ b/lib/methods/debounced-scroll.js
@@ -13,7 +13,7 @@ function debouncedScroll() {
 
         timeout = setTimeout(() => {
             scrollHandler(this.trackedElements, this.options);
-        }, this.options.throttle);
+        }, this.options.debounce);
     };
 }
 


### PR DESCRIPTION
There no longer is a "throttle" option, and because this code are looking for "throttle," debounces actually don't work.

See these fiddles for examples. Only change in the JS code for this is the change made in this PR

- **Debouncing not working**:
    https://jsfiddle.net/romellem/d8Lhge97/
- **Debouncing is working** (with PR change):
    https://jsfiddle.net/romellem/d8Lhge97/1/
